### PR TITLE
Hostgraph construction: reuse extracted hostlinks checkpointed on S3

### DIFF
--- a/src/script/hostgraph/build_hostgraph.sh
+++ b/src/script/hostgraph/build_hostgraph.sh
@@ -198,6 +198,10 @@ for CRAWL in ${CRAWLS[@]}; do
         fi
         # add the existing output splits as input for host graph and merged graph
         for output_split in $(hadoop fs -ls -C "$S3A_OUTPUT_PREFIX"/$CRAWL/hostlinks/); do
+            case "$output_split" in
+                */_SUCCESS )
+                    continue ;;
+            esac
             if [ -z "$HOSTGRAPH_INPUT" ]; then
                 HOSTGRAPH_INPUT="$output_split"
             else

--- a/src/script/hostgraph/hostgraph_config.sh
+++ b/src/script/hostgraph/hostgraph_config.sh
@@ -12,7 +12,7 @@
 ### saved as tuples <from_host, to_host>
 
 # crawls to be processed
-CRAWLS=("CC-MAIN-2023-23" "CC-MAIN-2023-40" "CC-MAIN-2023-50")
+CRAWLS=("CC-MAIN-2023-40" "CC-MAIN-2023-50" "CC-MAIN-2024-10")
 
 INPUT_BASE_URL="s3://commoncrawl/"
 
@@ -42,7 +42,7 @@ S3A_OUTPUT_PREFIX=s3a://commoncrawl-webgraph
 ################################################################################
 # construct a merged graph of multiple monthly crawls
 
-MERGE_NAME=cc-main-2023-may-sep-nov
+MERGE_NAME=cc-main-2023-24-sep-nov-feb
 
 # Naming convention should be the three months' crawls that are
 # used to generate this graph release. In the event of multiple months


### PR DESCRIPTION
- look on the S3 checkpoint/archive prefix for extracted hostlinks of every crawl to be processed
- if found use the checkpointed/archived data and do not extract the hostlinks again
- add success marker for processed crawl(s) to ensure that all input splits have been successfully processed