### PR TITLE
Bug fix counting top-level domains in node list

### DIFF
--- a/src/main/java/org/commoncrawl/webgraph/explore/Graph.java
+++ b/src/main/java/org/commoncrawl/webgraph/explore/Graph.java
@@ -255,8 +255,11 @@ public class Graph {
 						}
 						count++;
 					}
-					curr = next;
 					res.add(new SimpleEntry<>(tld, count));
+					curr = next;
+					if (!iter.hasNext()) {
+						break;
+					}
 				} while (curr > -1);
 			}
 			return res.stream().sorted(Collections.reverseOrder(Map.Entry.comparingByValue()));


### PR DESCRIPTION
For the last block of domain names in reversed notation, sharing the same TLD prefix, two counts are returned: the correct count and count "1", e.g.
```
za=555
za=1
```