### PR TITLE
Refactor host graph Spark configuration for larger graphs

### DIFF
--- a/src/script/hostgraph/build_hostgraph.sh
+++ b/src/script/hostgraph/build_hostgraph.sh
@@ -365,7 +365,7 @@ if [ -n "MERGE_NAME" ]; then
         --conf spark.io.compression.codec=zstd \
         --conf spark.checkpoint.compress=true \
         --num-executors $NUM_EXECUTORS \
-        --executor-cores $EXECUTOR_CORES \
+        --executor-cores $EXECUTOR_CORES_STEP2 \
         --executor-memory $EXECUTOR_MEM \
         --conf spark.sql.warehouse.dir=$WAREHOUSE_DIR \
         --conf spark.sql.parquet.compression.codec=zstd \


### PR DESCRIPTION
- Adapt the Spark configuration for building the host graphs to larger graphs (more edges), avoiding out-of-memory errors
- Add separate configuration of executor cores to run step 2 (merge from-to host link pairs and construct numeric graph)
- Assign less cores per executor running step 2
- Increase number of edge partitions