### PR TITLE
feat: use env for POSIX compliance on silly Mac systems

### DIFF
--- a/src/script/webgraph_ranking/graph_explore_build_vertex_map.sh
+++ b/src/script/webgraph_ranking/graph_explore_build_vertex_map.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Build node indexes to interactively explore a Common Crawl webgraph.
 # The webgraph files are expected to be placed in the current directory.

--- a/src/script/webgraph_ranking/graph_explore_download_webgraph.sh
+++ b/src/script/webgraph_ranking/graph_explore_download_webgraph.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NAME="$1"
 if ! shift 1; then


### PR DESCRIPTION
`declare -A` doesn't work on bash 4.0 (iirc) so using `env` in the shebang allows the use of bash installed via `brew` instead of the ridiculous 3.2.57 supplied with macos.